### PR TITLE
한줄평 좋아요 및 취소 업데이트

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const logger = require('morgan');
 const connect = require('./database/connect');
 const authRouter = require('./routes/auth');
 const bookRouter = require('./routes/book');
+const reviwerRouter = require('./routes/reviwer');
 const { ERROR } = require('./utils/constants');
 
 connect();
@@ -31,6 +32,7 @@ app.use(cors(corsOptions));
 
 app.use('/auth', authRouter);
 app.use('/book', bookRouter);
+app.use('/reviwer', reviwerRouter);
 
 app.use((req, res) => {
   res.status(404).send(ERROR.NOT_FOUND);

--- a/controllers/reviwer.js
+++ b/controllers/reviwer.js
@@ -1,0 +1,27 @@
+const Reviwer = require('../models/Reviwer');
+
+exports.updateReview = async (req, res) => {
+  const { reviwerId, creator, good } = req.body;
+
+  const reviwer = await Reviwer.findById(reviwerId);
+
+  if (!reviwer) {
+    return res.json({ error: '존재하지 않습니다' });
+  }
+
+  if (good) {
+    await Reviwer.findByIdAndUpdate(
+      reviwerId,
+      { $push: { likes: creator } },
+      { new: true }
+    );
+  } else {
+    await Reviwer.findByIdAndUpdate(
+      reviwerId,
+      { $pull: { likes: creator } },
+      { new: true }
+    );
+  }
+
+  res.json({ result: 'ok' });
+};

--- a/models/Book.js
+++ b/models/Book.js
@@ -1,27 +1,5 @@
 const mongoose = require('mongoose');
 
-const playerSchema = new mongoose.Schema({
-  id: {
-    type: mongoose.Types.ObjectId,
-    required: true,
-  },
-  creator: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
-  },
-  nickname: {
-    type: String,
-    required: true,
-  },
-  sound: {
-    type: String,
-    required: true,
-  },
-  likes: {
-    type: Array,
-  },
-});
-
 const BookSchema = new mongoose.Schema({
   bookTitle: {
     type: String,
@@ -39,7 +17,12 @@ const BookSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
-  players: [playerSchema],
+  reviwerHistory: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Reviwer',
+    },
+  ],
 });
 
 module.exports = mongoose.model('Book', BookSchema);

--- a/models/Record.js
+++ b/models/Record.js
@@ -1,6 +1,10 @@
 const mongoose = require('mongoose');
 
 const RecordSchema = new mongoose.Schema({
+  id: {
+    type: mongoose.Types.ObjectId,
+    required: true,
+  },
   bookTitle: {
     type: String,
     required: true,

--- a/models/Reviwer.js
+++ b/models/Reviwer.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+
+const ReviwerSchema = new mongoose.Schema({
+  id: {
+    type: mongoose.Types.ObjectId,
+    required: true,
+  },
+  nickname: {
+    type: String,
+    required: true,
+  },
+  sound: {
+    type: String,
+    required: true,
+  },
+  likes: {
+    type: Array,
+    required: true,
+  },
+});
+
+module.exports = mongoose.model('Reviwer', ReviwerSchema);

--- a/models/sample_book.json
+++ b/models/sample_book.json
@@ -4,88 +4,48 @@
     "author": "김호연",
     "imageUrl": "http://image.kyobobook.co.kr/images/book/large/188/l9791161571188.jpg",
     "introduction": "이책은 너무나도 소중하다",
-    "players": [
-      {
-        "id": "61fb6ad0939afdfb71e704af",
-        "creator": "61fb6ad0939afdfb71e704ag",
-        "nickname": "유관",
-        "sound": "abddwwwc",
-        "likes": []
-      }
-    ]
+    "reviwerHistory": ["621ba31416b34df406458cc5"]
   },
   {
     "bookTitle": "어서 오세요, 휴남동 서점입니다",
     "author": "황보름",
     "imageUrl": "http://image.kyobobook.co.kr/images/book/large/143/l9791197377143.jpg",
     "introduction": "이 책은 너무나도 아름답다",
-    "players": [
-      {
-        "id": "61fb6ad0939afdfb71e234af",
-        "creator": "61fb6ad0939afdfb71e704vg",
-        "nickname": "무관",
-        "sound": "abvvvvssrrrrwc",
-        "likes": []
-      }
-    ]
+    "reviwerHistory": ["621ba31416b34df406458cc5"]
   },
   {
     "bookTitle": "달러구트 꿈 백화점",
     "author": "이미예",
     "imageUrl": "http://image.kyobobook.co.kr/images/book/large/252/l9791165344252.jpg",
     "introduction": "이책은 너무나도 소중하다",
-    "players": [
-      {
-        "id": "61fb6ad0939afdfb71e704af",
-        "creator": "61fb6ad0939afdfb71e704ag",
-        "nickname": "주관",
-        "sound": "abddwrwrwrrwwc",
-        "likes": []
-      }
-    ]
+    "reviwerHistory": []
   },
   {
     "bookTitle": "지구 끝의 온실",
     "author": "김초엽",
     "imageUrl": "http://image.kyobobook.co.kr/images/book/large/001/l9791191824001.jpg",
     "introduction": "이책은 너무나도 소중하다",
-    "players": [
-      {
-        "id": "61fb6ad0939afdfb71e704af",
-        "creator": "61fb6ad0939afdfb71e704ag",
-        "nickname": "사관",
-        "sound": "abddwweewwwc",
-        "likes": []
-      }
-    ]
+    "reviwerHistory": []
   },
   {
     "bookTitle": "밝은 밤",
     "author": "최은영",
     "imageUrl": "http://image.kyobobook.co.kr/images/book/large/179/l9788954681179.jpg",
     "introduction": "이책은 너무나도 소중하다",
-    "players": [
-      {
-        "id": "61fb6ad0939afdfb71e704af",
-        "creator": "61fb6ad0939afdfb71e704ag",
-        "nickname": "이관",
-        "sound": "adwdwdwwwq",
-        "likes": []
-      }
-    ]
+    "reviwerHistory": []
   },
   {
     "bookTitle": "장미의 이름은 장미 ",
     "author": "은희경",
     "imageUrl": "http://image.kyobobook.co.kr/images/book/large/736/l9788954684736.jpg",
     "introduction": "이책은 너무나도 소중하다",
-    "players": [{}]
+    "reviwerHistory": []
   },
   {
     "bookTitle": "아몬드",
     "author": "손원평",
     "imageUrl": "http://image.kyobobook.co.kr/images/book/large/267/l9788936434267.jpg",
     "introduction": "이책은 너무나도 소중하다",
-    "players": [{}]
+    "reviwerHistory": []
   }
 ]

--- a/routes/reviwer.js
+++ b/routes/reviwer.js
@@ -1,0 +1,9 @@
+const express = require('express');
+
+const reviwerController = require('../controllers/auth');
+
+const router = express.Router();
+
+router.put('/', reviwerController.updateReview);
+
+module.exports = router;


### PR DESCRIPTION
# 한줄평 좋아요 및 취소 업데이트

## 노션 칸반 링크

- [PUT/book/:id - 좋아요 및 취소](https://www.notion.so/PUT-book-id-5db8cc8f4ca34740a48e4f473a567b50)

## 구현사항
- 사용자가 좋아요를 누르면 해당하는 reviwer 아이디값을 찾고 배열에 아이디 값을 넣어준다
- 사용자가 좋아요를 취소할 시, 아이디 값을 빼준다

## 테스트 방법
- 아틀란스 및 포스트맨 사용

## 보고 사항
- 현재 Book의 subSchema였던 players를 따로 modles폴더 - Reviwer.js 파일로 구성
- 그랬을 시 해당 id값을 찾고 배열에 값을 넣어주는 부분이 더 빠르고 간결하게 구성
